### PR TITLE
Update `config.statuspageUrl` to https://alerts.library.nyu.edu/api/v2/summary.json

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -22,7 +22,12 @@ const config = {
     verifying: 'green',
   },
   stylesheetPath: '/index.min.css',
-  statuspageUrl: 'https://kyyfz4489y7m.statuspage.io/api/v2/summary.json',
+  // The official URL is documented at https://alerts.library.nyu.edu/api/v2/,
+  // section "Summary".
+  // The "https://kyyfz4489y7m.statuspage.io/api/v2/summary.json" URL works, but
+  // it is deprecated. See response from Daniel Eads in this forum post page:
+  // https://community.atlassian.com/forums/Statuspage-questions/StatusPage-io-v2-api-subscribers-endpoint-not-returning-all/qaq-p/944674
+  statuspageUrl: 'https://alerts.library.nyu.edu/api/v2/summary.json',
 };
 
 config.stylesheetUrl = getBaseUrl() + config.stylesheetPath;


### PR DESCRIPTION
**EDIT: The code for this branch that was presumably deployed to dev (automatically, the moment the branch was pushed, as configured in CircleCI) appears to have been reverted, or else never deployed.  Chronologically the tip of that branch was the latest to deploy, and it's date is the closest to current S3 timestamps for the deployed code (times are within hours of each other), but the state of the S3 files is in fact identical with that of the branch for the PR opened previous to this one -- [Select Statuspage API summary\.json URL based on source file hosting CDN's hostname](https://github.com/NYULibraries/statuspage-embed/pull/62).  The CircleCI build/deploy records for these branches have disappeared, so there's no way to know for sure what happened.** 

**As of 2026-03-19, the state of dev is identical to the branch for the [Select Statuspage API summary\.json URL based on source file hosting CDN's hostname](https://github.com/NYULibraries/statuspage-embed/pull/62) PR.**

**Writing this note in the PR because there's no way to add a note to a branch.**