### PR TITLE
`config.getBaseUrl()`: replace `DEPLOY_ENV` based branching with `document.currentScript` based branching

### DIFF
--- a/js/alertBanner.js
+++ b/js/alertBanner.js
@@ -39,7 +39,7 @@ class AlertBanner {
         const linkDiv = document.createElement( 'link' );
         linkDiv.setAttribute( 'rel', 'stylesheet' );
         linkDiv.setAttribute( 'type', 'text/css' );
-        linkDiv.setAttribute( 'href', config.stylesheetUrl );
+        linkDiv.setAttribute( 'href', config.getStylesheetUrl() );
         return document.head.appendChild( linkDiv );
     }
 

--- a/js/config.js
+++ b/js/config.js
@@ -30,6 +30,9 @@ function getStatuspageSummaryUrl() {
 
 // need to factor this out into separate yaml/json file
 const config = {
+    getStylesheetUrl: function() {
+        return getBaseUrl() + '/index.min.css';
+    },
     statusToColorMapping: {
         investigating: 'red',
         identified   : 'orange',
@@ -39,10 +42,7 @@ const config = {
         scheduled    : 'green',
         verifying    : 'green',
     },
-    stylesheetPath: '/index.min.css',
 };
-
-config.stylesheetUrl = getBaseUrl() + config.stylesheetPath;
 
 export {
     config as default,

--- a/js/config.js
+++ b/js/config.js
@@ -1,13 +1,7 @@
-// TODO: Replace with https://alerts-dev.library.nyu.edu/api/v2/summary.json
-// See comment for PROD_STATUSPAGE_SUMMARY_URL.  We would first need to create
-// the CNAME.
-const DEV_STATUSPAGE_SUMMARY_URL = 'https://9bz1fsjktmnp.statuspage.io/api/v2/summary.json';
-// TODO: Replace this with https://alerts.library.nyu.edu/api/v2/summary.json,
-// which is the value shown in the API settings: https://public.statuspage.io/api/v2#summary
-// URLs of the form *.statuspage.io/api/v2/ are deprecated.  Source (response from Daniel Eads):
-// "StatusPage.io v2 api subscribers endpoint not returning all subscribers"
-// https://community.atlassian.com/forums/Statuspage-questions/StatusPage-io-v2-api-subscribers-endpoint-not-returning-all/qaq-p/944674)
-const PROD_STATUSPAGE_SUMMARY_URL = 'https://kyyfz4489y7m.statuspage.io/api/v2/summary.json';
+const DEV_STATUSPAGE_SUMMARY_URL =
+    'https://alerts-dev.library.nyu.edu/api/v2/summary.json';
+const PROD_STATUSPAGE_SUMMARY_URL =
+    'https://alerts.library.nyu.edu/api/v2/summary.json';
 
 // determine base url for stylesheet based on environment
 function getBaseUrl() {

--- a/js/config.js
+++ b/js/config.js
@@ -1,3 +1,6 @@
+const DEV_CDN_HOSTNAME = 'cdn-dev.library.nyu.edu';
+const PROD_CDN_HOSTNAME = 'cdn.library.nyu.edu';
+
 const DEV_STATUSPAGE_SUMMARY_URL =
     'https://alerts-dev.library.nyu.edu/api/v2/summary.json';
 const PROD_STATUSPAGE_SUMMARY_URL =
@@ -5,10 +8,12 @@ const PROD_STATUSPAGE_SUMMARY_URL =
 
 // determine base url for stylesheet based on environment
 function getBaseUrl() {
-    switch ( process.env.DEPLOY_ENV ) {
-        case 'production':
+    const sourceFileHostname = new URL( document.currentScript.src ).hostname;
+
+    switch ( sourceFileHostname ) {
+        case PROD_CDN_HOSTNAME:
             return 'https://cdn.library.nyu.edu/statuspage-embed';
-        case 'staging':
+        case DEV_CDN_HOSTNAME:
             return 'https://cdn-dev.library.nyu.edu/statuspage-embed';
         default:
             return '/dist';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:prod": "NODE_ENV=${NODE_ENV:-production} npm run build -- --mode=production --env DEPLOY_ENV=production",
     "eslint": "eslint . --ext .js,.jsx,.cjs,.mjs",
     "eslint:fix": "npm run eslint -- --fix",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "devDependencies": {
     "@babel/core": "7.24.7",

--- a/spec/alertBanner.spec.js
+++ b/spec/alertBanner.spec.js
@@ -79,6 +79,8 @@ describe( '#insertStylesheet', () => {
     } );
 
     it( 'should insert stylesheet when called', () => {
+        document.currentScript.src = 'https://localhost';
+
         expect( AlertBanner.insertStylesheet() ).toBeTruthy();
         expect( document.head.children.length ).toBe( 1 );
         expect( document.head.firstChild.tagName ).toEqual( 'LINK' );

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     DEV_STATUSPAGE_SUMMARY_URL,
@@ -8,28 +8,22 @@ import {
 } from '../js/config';
 
 describe( 'getBaseUrl', () => {
-    const OLD_ENV = process.env;
-
     beforeEach( () => {
         vi.resetModules();
-        process.env = { ...OLD_ENV };
-    } );
-
-    afterEach( () => {
-        process.env = OLD_ENV;
     } );
 
     it( 'should set properly for local', () => {
+        document.currentScript.src = 'https://localhost';
         expect( getBaseUrl() ).toEqual( '/dist' );
     } );
 
-    it( 'should set properly for staging', () => {
-        process.env.DEPLOY_ENV = 'staging';
+    it( 'should set properly for dev', () => {
+        document.currentScript.src = 'https://cdn-dev.library.nyu.edu';
         expect( getBaseUrl() ).toEqual( 'https://cdn-dev.library.nyu.edu/statuspage-embed' );
     } );
 
-    it( 'should set properly for production', () => {
-        process.env.DEPLOY_ENV = 'production';
+    it( 'should set properly for prod', () => {
+        document.currentScript.src = 'https://cdn.library.nyu.edu';
         expect( getBaseUrl() ).toEqual( 'https://cdn.library.nyu.edu/statuspage-embed' );
     } );
 } );


### PR DESCRIPTION
Using `DEPLOY_ENV` env var to set return value for `config.getBaseUrl()` leads to differences in _dist/_ code based on environment.  In at least one instance this made it harder to know what branch tip was currently deployed to dev (see this PR: [Update config\.statuspageUrl to https://alerts\.library\.nyu\.edu/api/v2/summary\.json](https://github.com/NYULibraries/statuspage-embed/pull/63)), because diff'ing the deployed code against a locally generated distribution was tricky.

We already use `document.currentScript` to do dynamic URL generation for the statuspage REST API endpoint, so we replace the problematic `DEPLOY_ENV` method with our standard method for configuration on the fly for each environment.